### PR TITLE
qt5-webengine: drop libXslt, libxml2 deps

### DIFF
--- a/community/qt5-webengine/depends
+++ b/community/qt5-webengine/depends
@@ -7,11 +7,9 @@ gperf make
 libXcomposite
 libXcursor
 libXi
-libXslt
 libXtst
 libdrm
 libevent
-libxml2
 linux-headers make
 nss
 python2 make

--- a/community/qt5/depends
+++ b/community/qt5/depends
@@ -9,7 +9,6 @@ libXext
 libXi
 libXrandr
 libXrender
-libXslt
 libinput
 libjpeg-turbo
 libpng


### PR DESCRIPTION
You'll have to trust me that this builds fine :v 