### PR TITLE
chromium: fix patch application with GNU patch

### DIFF
--- a/community/chromium/build
+++ b/community/chromium/build
@@ -25,6 +25,7 @@ python3 ungoogled-chromium/utils/prune_binaries.py \
 
 # Bypass the Python script and apply patches ourselves to avoid GNU patch.
 while read -r patch; do
+    [ "$patch" ] || continue
     patch -p1 < "ungoogled-chromium/patches/$patch"
 done < ungoogled-chromium/patches/series
 


### PR DESCRIPTION
The `series` files contains an empty line:

```
core/bromite/disable-fetching-field-trials.patch

extra/inox-patchset/0006-modify-default-prefs.patch
```

```
patch -p1 < "ungoogled-chromium/patches/$patch"
```

`busybox` patch just ignores dirs but GNU complains.

```
-> patch -p1 < kiss/
-> kiss a patch /usr/bin/patch
-> Using '/usr/bin/ssu' (to become root)
-> Swapping '/usr/bin/patch' from 'busybox' to 'patch'
-> patch -p1 < kiss/
patch: **** read error : Is a directory
```
