### PR TITLE
rxvt-unicode: force -std=c++11

### DIFF
--- a/community/rxvt-unicode/build
+++ b/community/rxvt-unicode/build
@@ -1,5 +1,8 @@
 #!/bin/sh -e
 
+# Fix GCC 11.
+export CXXFLAGS="$CXXFLAGS -std=c++11"
+
 patch -p1 < rxvt-unicode-kerning.patch
 patch -p1 < gentables.patch
 


### PR DESCRIPTION
Since I don't have GCC, I can't reproduce the problem since I don't know if GCC 11 uses C++17 by deafult. But yeah I can't build it with `-std=c++17` in Clang.

## Installed manifest of package

Irrelevant.

## Existing package

- [x] I am the maintainer of this package.