### PR TITLE
powertop: fix depends

### DIFF
--- a/community/powertop/depends
+++ b/community/powertop/depends
@@ -1,4 +1,5 @@
 autoconf-archive    make
+automake            make
 libnl
 libtool             make
 ncurses


### PR DESCRIPTION
Fixing make depend, as reported by irc/ang

## Installed manifest of package

```
/var/db/kiss/installed/powertop/version
/var/db/kiss/installed/powertop/sources
/var/db/kiss/installed/powertop/manifest
/var/db/kiss/installed/powertop/depends
/var/db/kiss/installed/powertop/checksums
/var/db/kiss/installed/powertop/build
/var/db/kiss/installed/powertop/
/var/db/kiss/installed/
/var/db/kiss/
/var/db/
/var/
/usr/share/man/man8/powertop.8
/usr/share/man/man8/
/usr/share/man/
/usr/share/bash-completion/completions/powertop
/usr/share/bash-completion/completions/
/usr/share/bash-completion/
/usr/share/
/usr/bin/powertop
/usr/bin/
/usr/
```

## Existing package

- [X] I am the maintainer of this package.
